### PR TITLE
Made using the access control decorator simpler (maybe?)

### DIFF
--- a/src/i19_bluesky/optics/check_access_control.py
+++ b/src/i19_bluesky/optics/check_access_control.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from functools import wraps
-from typing import Callable, ParamSpec, TypeVar
+from typing import Callable, Concatenate, ParamSpec, TypeVar
 
 import bluesky.plan_stubs as bps
 from bluesky.utils import MsgGenerator
@@ -17,7 +17,9 @@ class HutchName(str, Enum):
     EH2 = "EH2"
 
 
-def check_access(wrapped_plan: Callable[P, MsgGenerator]):
+def check_access(
+    wrapped_plan: Callable[P, MsgGenerator],
+) -> Callable[Concatenate[HutchName, HutchAccessControl, P], MsgGenerator]:
     @wraps(wrapped_plan)
     def safe_plan(
         experiment_hutch: HutchName,

--- a/src/i19_bluesky/optics/experiment_shutter_plans.py
+++ b/src/i19_bluesky/optics/experiment_shutter_plans.py
@@ -2,25 +2,15 @@ import bluesky.plan_stubs as bps
 from bluesky.utils import MsgGenerator
 from dodal.common import inject
 from dodal.devices.hutch_shutter import HutchShutter, ShutterDemand
-from dodal.devices.i19.hutch_access import HutchAccessControl
 
 from i19_bluesky.log import LOGGER
-from i19_bluesky.optics.check_access_control import HutchName, check_access
+from i19_bluesky.optics.check_access_control import check_access
 
 
+@check_access
 def operate_shutter_plan(
-    from_hutch: HutchName,
     shutter_demand: ShutterDemand,
     shutter: HutchShutter = inject("shutter"),  # noqa: B008
-    access_control: HutchAccessControl = inject("access_control"),  # noqa: B008
 ) -> MsgGenerator:
-    LOGGER.debug(f"Trying to operate the hutch shutter from {from_hutch.value}")
-
-    @check_access(access_control, from_hutch)
-    def move_hutch_shutter(
-        shutter: HutchShutter, request: ShutterDemand
-    ) -> MsgGenerator:
-        LOGGER.info(f"Moving experiment shutter to {request}.")
-        yield from bps.abs_set(shutter, request, wait=True)
-
-    yield from move_hutch_shutter(shutter, shutter_demand)
+    LOGGER.info(f"Moving experiment shutter to {shutter_demand}.")
+    yield from bps.abs_set(shutter, shutter_demand, wait=True)

--- a/tests/unit_tests/optics/test_shutter_plans.py
+++ b/tests/unit_tests/optics/test_shutter_plans.py
@@ -89,7 +89,7 @@ async def test_hutch_shutter_opens_and_closes_if_run_by_active_hutch(
     set_mock_value(expt_shutter.status, start_state)
     RE(
         operate_shutter_plan(
-            request_hutch, shutter_demand, expt_shutter, access_control_device
+            request_hutch, access_control_device, shutter_demand, expt_shutter
         )
     )
 
@@ -143,7 +143,7 @@ async def test_hutch_shutter_does_not_operate_from_wrong_hutch(
     set_mock_value(expt_shutter.status, start_state)
     RE(
         operate_shutter_plan(
-            request_hutch, shutter_demand, expt_shutter, access_control_device
+            request_hutch, access_control_device, shutter_demand, expt_shutter
         )
     )
 


### PR DESCRIPTION
Example based on https://github.com/DiamondLightSource/i19-bluesky/pull/38

The advantage is that using `check_access` is simpler than the original PR i.e. the code in `experiment_shutter_plans` is more readable and if we're adding `check_access` in lots of places this is nice. However, disadvantages are:
* `check_access_control.py` is now more complex with `ParamSpec` etc.
* It is not obvious from `experiment_shutter_plans.py` that you must also specify a hutch and a `HutchAccessControl` when calling the plan (though the type system catches it)
* I haven't tested it with BlueAPI, not sure how happy the type introspection on that will be (@DiamondJoseph or @callumforrester)
* As written I couldn't find a way of getting the `inject("access_control")` in. This means that, if we can get it to work with `blueapi` we will need to provide this on the client side