### PR TITLE
Adjust check_access until working with blueapi

### DIFF
--- a/src/i19_bluesky/optics/__init__.py
+++ b/src/i19_bluesky/optics/__init__.py
@@ -1,5 +1,5 @@
 """A place for plans controlling the optics."""
 
-from .experiment_shutter_plans import operate_shutter_plan
+from .experiment_shutter_plans import HutchShutter, operate_shutter_plan
 
-__all__ = ["operate_shutter_plan"]
+__all__ = ["operate_shutter_plan", "HutchShutter"]

--- a/src/i19_bluesky/optics/check_access_control.py
+++ b/src/i19_bluesky/optics/check_access_control.py
@@ -53,7 +53,7 @@ def check_access(
                 kind=Parameter.POSITIONAL_OR_KEYWORD,
                 annotation=HutchAccessControl,
             ),
-            *[p for p in sig.parameters.values()],  # noqa
+            *list(sig.parameters.values()),
         ]
     )
     safe_plan.__annotations__.update(

--- a/src/i19_bluesky/optics/check_access_control.py
+++ b/src/i19_bluesky/optics/check_access_control.py
@@ -1,5 +1,6 @@
 from enum import Enum
 from functools import wraps
+from inspect import Parameter, signature
 from typing import Callable, Concatenate, ParamSpec, TypeVar
 
 import bluesky.plan_stubs as bps
@@ -11,31 +12,52 @@ from i19_bluesky.log import LOGGER
 P = ParamSpec("P")
 R = TypeVar("R")
 
-
 class HutchName(str, Enum):
     EH1 = "EH1"
     EH2 = "EH2"
 
-
 def check_access(
-    wrapped_plan: Callable[P, MsgGenerator],
-) -> Callable[Concatenate[HutchName, HutchAccessControl, P], MsgGenerator]:
+    wrapped_plan: Callable[P, MsgGenerator[R]],
+) -> Callable[Concatenate[HutchName, HutchAccessControl, P], MsgGenerator[R | None]]:
     @wraps(wrapped_plan)
     def safe_plan(
         experiment_hutch: HutchName,
         access_device: HutchAccessControl,
         *args: P.args,
         **kwargs: P.kwargs,
-    ):
+    ) -> MsgGenerator[R | None]:
         active_hutch = yield from bps.rd(access_device.active_hutch)
 
-        def access_denied_plan() -> MsgGenerator:
+        if active_hutch == experiment_hutch.value:
+            r = yield from wrapped_plan(*args, **kwargs)
+            return r
+        else:
             LOGGER.warning(f"Active hutch is {active_hutch}, plan will not run.")
             yield from bps.null()
+            return None
+        
+    sig = signature(wrapped_plan)
 
-        if active_hutch == experiment_hutch.value:
-            yield from wrapped_plan(*args, **kwargs)
-        else:
-            yield from access_denied_plan()
+    safe_plan.__signature__ = sig.replace(  # type: ignore
+        parameters=[
+            Parameter(
+                name="experiment_hutch",
+                kind=Parameter.POSITIONAL_OR_KEYWORD,
+                annotation=HutchName
+                ),
+            Parameter(
+                name="access_device",
+                kind=Parameter.POSITIONAL_OR_KEYWORD,
+                annotation=HutchAccessControl
+                ),
+                p for p in sig.parameters.values()
+            ]
+        )
+    safe_plan.__annotations__.update(
+        {
+            "experiment_hutch": HutchName,
+            "access_device": HutchAccessControl
+        }
+    )
 
     return safe_plan


### PR DESCRIPTION
I wanted to play around with this to make sure it worked with blueapi's turning of plan arguments into a model- it ended up being more work than I thought so I wanted to park it here for inspection.

The schema generated in blueapi main by this:

```json
{
  "name": "operate_shutter_plan",
  "description": null,
  "schema": {
    "$defs": {
      "HutchName": {
        "enum": [
          "EH1",
          "EH2"
        ],
        "title": "HutchName",
        "type": "string"
      },
      "ShutterDemand": {
        "enum": [
          "Open",
          "Close",
          "Reset"
        ],
        "title": "ShutterDemand",
        "type": "string"
      }
    },
    "additionalProperties": false,
    "properties": {
      "experiment_hutch": {
        "$ref": "#/$defs/HutchName"
      },
      "access_device": {
        "title": "Access Device",
        "type": "dodal.devices.i19.hutch_access.HutchAccessControl"
      },
      "shutter_demand": {
        "$ref": "#/$defs/ShutterDemand"
      },
      "shutter": {
        "title": "Shutter",
        "type": "dodal.devices.hutch_shutter.HutchShutter"
      }
    },
    "required": [
      "experiment_hutch",
      "access_device",
      "shutter_demand"
    ],
    "title": "operate_shutter_plan",
    "type": "object"
  }
}
```