### PR TITLE
Pin pyright to working version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,8 @@ dev = [
     "pipdeptree",
     "pre-commit",
     "pydata-sphinx-theme>=0.12",
-    "pyright",
+    # Pin pyright until https://github.com/microsoft/pyright/issues/11060 is fixed
+    "pyright==1.1.406",
     "pytest",
     "pytest-asyncio",
     "pytest-cov",


### PR DESCRIPTION
Fixes linter breaking caused by new version of pyright (1.1.407) by pinning it to earlier one.

See [pyright#11060](https://github.com/microsoft/pyright/issues/11060)

Instructions to reviewer on how to test:
- Linting passes