### PR TITLE
Add EH plans for setting attenuator squad positions

### DIFF
--- a/src/i19_bluesky/eh1/__init__.py
+++ b/src/i19_bluesky/eh1/__init__.py
@@ -2,14 +2,16 @@
 
 from i19_bluesky.eh1.pin_tip_detection import pin_tip_detection_plan
 from i19_bluesky.plans.optics_hutch_control_plans import (
+    apply_attenuator_positions,
     apply_voltage_to_piezo_actuators,
     close_experiment_shutter,
     open_experiment_shutter,
 )
 
 __all__ = [
-    "open_experiment_shutter",
-    "close_experiment_shutter",
+    "apply_attenuator_positions",
     "apply_voltage_to_piezo_actuators",
+    "close_experiment_shutter",
+    "open_experiment_shutter",
     "pin_tip_detection_plan",
 ]

--- a/src/i19_bluesky/eh2/__init__.py
+++ b/src/i19_bluesky/eh2/__init__.py
@@ -5,15 +5,17 @@ from i19_bluesky.eh2.pincol_control_plans import (
     move_pin_col_to_requested_in_position,
 )
 from i19_bluesky.plans.optics_hutch_control_plans import (
+    apply_attenuator_positions,
     apply_voltage_to_piezo_actuators,
     close_experiment_shutter,
     open_experiment_shutter,
 )
 
 __all__ = [
-    "open_experiment_shutter",
+    "apply_attenuator_positions",
+    "apply_voltage_to_piezo_actuators",
     "close_experiment_shutter",
     "move_pin_col_out_of_beam",
     "move_pin_col_to_requested_in_position",
-    "apply_voltage_to_piezo_actuators",
+    "open_experiment_shutter",
 ]

--- a/src/i19_bluesky/plans/optics_hutch_control_plans.py
+++ b/src/i19_bluesky/plans/optics_hutch_control_plans.py
@@ -4,6 +4,10 @@ from one of the hutches."""
 import bluesky.plan_stubs as bps
 from bluesky.utils import MsgGenerator
 from dodal.common import inject
+from dodal.devices.beamlines.i19.access_controlled.attenuator_motor_squad import (
+    AttenuatorMotorPositionDemands,
+    AttenuatorMotorSquad,
+)
 from dodal.devices.beamlines.i19.access_controlled.piezo_control import (
     AccessControlledPiezoActuator,
 )
@@ -13,6 +17,21 @@ from dodal.devices.beamlines.i19.access_controlled.shutter import (
 from dodal.devices.hutch_shutter import ShutterDemand
 
 from i19_bluesky.log import LOGGER
+
+
+def apply_attenuator_positions(
+    motor_squad: AttenuatorMotorSquad, position_demands: AttenuatorMotorPositionDemands
+) -> MsgGenerator[None]:
+    validated_demands = position_demands.validated_complete_demand()
+    LOGGER.info(f"Applying position demands {validated_demands} to attenuator elements")
+    yield from bps.abs_set(motor_squad, position_demands, wait=True)
+
+
+def apply_voltage_to_piezo_actuators(
+    requested_voltage: float, piezo_device: AccessControlledPiezoActuator
+) -> MsgGenerator[None]:
+    LOGGER.info(f"Applying {requested_voltage} to {piezo_device.name}")
+    yield from bps.abs_set(piezo_device, requested_voltage, wait=True)
 
 
 def open_experiment_shutter(
@@ -27,10 +46,3 @@ def close_experiment_shutter(
 ) -> MsgGenerator[None]:
     LOGGER.debug("Send command to close the shutter.")
     yield from bps.abs_set(shutter, ShutterDemand.CLOSE, wait=True)
-
-
-def apply_voltage_to_piezo_actuators(
-    requested_voltage: float, piezo_device: AccessControlledPiezoActuator
-) -> MsgGenerator[None]:
-    LOGGER.info(f"Applying {requested_voltage} to {piezo_device.name}")
-    yield from bps.abs_set(piezo_device, requested_voltage, wait=True)

--- a/src/i19_bluesky/plans/optics_hutch_control_plans.py
+++ b/src/i19_bluesky/plans/optics_hutch_control_plans.py
@@ -4,6 +4,10 @@ from one of the hutches."""
 import bluesky.plan_stubs as bps
 from bluesky.utils import MsgGenerator
 from dodal.common import inject
+from dodal.devices.beamlines.i19.access_controlled.attenuator_motor_squad import (
+    AttenuatorMotorPositionDemands,
+    AttenuatorMotorSquad,
+)
 from dodal.devices.beamlines.i19.access_controlled.piezo_control import (
     AccessControlledPiezoActuator,
 )
@@ -13,6 +17,22 @@ from dodal.devices.beamlines.i19.access_controlled.shutter import (
 from dodal.devices.hutch_shutter import ShutterDemand
 
 from i19_bluesky.log import LOGGER
+
+
+def apply_attenuator_positions(
+    position_demands: AttenuatorMotorPositionDemands,
+    motor_squad: AttenuatorMotorSquad = inject("attenuator_motor_squad"),
+) -> MsgGenerator[None]:
+    validated_demands = position_demands.validated_complete_demand()
+    LOGGER.info(f"Applying position demands {validated_demands} to attenuator elements")
+    yield from bps.abs_set(motor_squad, position_demands, wait=True)
+
+
+def apply_voltage_to_piezo_actuators(
+    requested_voltage: float, piezo_device: AccessControlledPiezoActuator
+) -> MsgGenerator[None]:
+    LOGGER.info(f"Applying {requested_voltage} to {piezo_device.name}")
+    yield from bps.abs_set(piezo_device, requested_voltage, wait=True)
 
 
 def open_experiment_shutter(
@@ -27,10 +47,3 @@ def close_experiment_shutter(
 ) -> MsgGenerator[None]:
     LOGGER.debug("Send command to close the shutter.")
     yield from bps.abs_set(shutter, ShutterDemand.CLOSE, wait=True)
-
-
-def apply_voltage_to_piezo_actuators(
-    requested_voltage: float, piezo_device: AccessControlledPiezoActuator
-) -> MsgGenerator[None]:
-    LOGGER.info(f"Applying {requested_voltage} to {piezo_device.name}")
-    yield from bps.abs_set(piezo_device, requested_voltage, wait=True)

--- a/tests/unit_tests/eh1/conftest.py
+++ b/tests/unit_tests/eh1/conftest.py
@@ -1,5 +1,8 @@
 import pytest
 from bluesky.run_engine import RunEngine
+from dodal.devices.beamlines.i19.access_controlled.attenuator_motor_squad import (
+    AttenuatorMotorSquad,
+)
 from dodal.devices.beamlines.i19.access_controlled.piezo_control import (
     AccessControlledPiezoActuator,
     FocusingMirrorName,
@@ -9,6 +12,17 @@ from dodal.devices.beamlines.i19.access_controlled.shutter import (
     HutchState,
 )
 from ophyd_async.core import set_mock_value
+
+
+@pytest.fixture
+async def attenuator_motor_squad(RE: RunEngine) -> AttenuatorMotorSquad:
+    att_motor_squad = AttenuatorMotorSquad(
+        hutch=HutchState.EH1, name="mock_attenuator_motors"
+    )
+    await att_motor_squad.connect(mock=True)
+
+    att_motor_squad.url = "http://test-blueapi.url"
+    return att_motor_squad
 
 
 @pytest.fixture

--- a/tests/unit_tests/eh1/test_optics_hutch_control.py
+++ b/tests/unit_tests/eh1/test_optics_hutch_control.py
@@ -1,6 +1,10 @@
 from unittest.mock import MagicMock, patch
 
 from bluesky.run_engine import RunEngine
+from dodal.devices.beamlines.i19.access_controlled.attenuator_motor_squad import (
+    AttenuatorMotorPositionDemands,
+    AttenuatorMotorSquad,
+)
 from dodal.devices.beamlines.i19.access_controlled.piezo_control import (
     AccessControlledPiezoActuator,
 )
@@ -14,8 +18,25 @@ from i19_bluesky.eh1 import (
     open_experiment_shutter,
 )
 from i19_bluesky.plans.optics_hutch_control_plans import (
+    apply_attenuator_positions,
     apply_voltage_to_piezo_actuators,
 )
+
+
+@patch("i19_bluesky.plans.optics_hutch_control_plans.bps.abs_set")
+async def test_apply_attenuator_positions(
+    mock_set: MagicMock, attenuator_motor_squad: AttenuatorMotorSquad, RE: RunEngine
+):
+    xy_demands = {"X": 25.37, "Y": 18.091}
+    filter_wheel_demands = {"W": 4}
+    position_demands = AttenuatorMotorPositionDemands(
+        continuous_demands=xy_demands, indexed_demands=filter_wheel_demands
+    )
+    RE(apply_attenuator_positions(attenuator_motor_squad, position_demands))
+
+    mock_set.assert_called_once_with(
+        attenuator_motor_squad, position_demands, wait=True
+    )
 
 
 @patch("i19_bluesky.plans.optics_hutch_control_plans.bps.abs_set")

--- a/tests/unit_tests/eh1/test_optics_hutch_control.py
+++ b/tests/unit_tests/eh1/test_optics_hutch_control.py
@@ -1,6 +1,10 @@
 from unittest.mock import MagicMock, patch
 
 from bluesky.run_engine import RunEngine
+from dodal.devices.beamlines.i19.access_controlled.attenuator_motor_squad import (
+    AttenuatorMotorPositionDemands,
+    AttenuatorMotorSquad,
+)
 from dodal.devices.beamlines.i19.access_controlled.piezo_control import (
     AccessControlledPiezoActuator,
 )
@@ -14,8 +18,25 @@ from i19_bluesky.eh1 import (
     open_experiment_shutter,
 )
 from i19_bluesky.plans.optics_hutch_control_plans import (
+    apply_attenuator_positions,
     apply_voltage_to_piezo_actuators,
 )
+
+
+@patch("i19_bluesky.plans.optics_hutch_control_plans.bps.abs_set")
+async def test_apply_attenuator_positions(
+    mock_set: MagicMock, attenuator_motor_squad: AttenuatorMotorSquad, RE: RunEngine
+):
+    xy_demands = {"X": 25.37, "Y": 18.091}
+    filter_wheel_demands = {"W": 4}
+    position_demands = AttenuatorMotorPositionDemands(
+        continuous_demands=xy_demands, indexed_demands=filter_wheel_demands
+    )
+    RE(apply_attenuator_positions(position_demands, attenuator_motor_squad))
+
+    mock_set.assert_called_once_with(
+        attenuator_motor_squad, position_demands, wait=True
+    )
 
 
 @patch("i19_bluesky.plans.optics_hutch_control_plans.bps.abs_set")

--- a/tests/unit_tests/eh2/conftest.py
+++ b/tests/unit_tests/eh2/conftest.py
@@ -1,6 +1,9 @@
 import pytest
 from bluesky.run_engine import RunEngine
 from dodal.beamlines import i19_2
+from dodal.devices.beamlines.i19.access_controlled.attenuator_motor_squad import (
+    AttenuatorMotorSquad,
+)
 from dodal.devices.beamlines.i19.access_controlled.piezo_control import (
     AccessControlledPiezoActuator,
     FocusingMirrorName,
@@ -12,6 +15,17 @@ from dodal.devices.beamlines.i19.access_controlled.shutter import (
 from dodal.devices.beamlines.i19.backlight import BacklightPosition
 from dodal.devices.beamlines.i19.pin_col_stages import PinholeCollimatorControl
 from ophyd_async.core import set_mock_value
+
+
+@pytest.fixture
+async def attenuator_motor_squad(RE: RunEngine) -> AttenuatorMotorSquad:
+    att_motor_squad = AttenuatorMotorSquad(
+        hutch=HutchState.EH2, name="mock_attenuator_motors"
+    )
+    await att_motor_squad.connect(mock=True)
+
+    att_motor_squad.url = "http://test-blueapi.url"
+    return att_motor_squad
 
 
 @pytest.fixture

--- a/tests/unit_tests/eh2/test_optics_hutch_control.py
+++ b/tests/unit_tests/eh2/test_optics_hutch_control.py
@@ -1,6 +1,10 @@
 from unittest.mock import MagicMock, patch
 
 from bluesky.run_engine import RunEngine
+from dodal.devices.beamlines.i19.access_controlled.attenuator_motor_squad import (
+    AttenuatorMotorPositionDemands,
+    AttenuatorMotorSquad,
+)
 from dodal.devices.beamlines.i19.access_controlled.piezo_control import (
     AccessControlledPiezoActuator,
 )
@@ -14,8 +18,25 @@ from i19_bluesky.eh2 import (
     open_experiment_shutter,
 )
 from i19_bluesky.plans.optics_hutch_control_plans import (
+    apply_attenuator_positions,
     apply_voltage_to_piezo_actuators,
 )
+
+
+@patch("i19_bluesky.plans.optics_hutch_control_plans.bps.abs_set")
+async def test_apply_attenuator_positions(
+    mock_set: MagicMock, attenuator_motor_squad: AttenuatorMotorSquad, RE: RunEngine
+):
+    xy_demands = {"X": 15.71, "Y": 38.16}
+    filter_wheel_demands = {"W": 2}
+    position_demands = AttenuatorMotorPositionDemands(
+        continuous_demands=xy_demands, indexed_demands=filter_wheel_demands
+    )
+    RE(apply_attenuator_positions(position_demands, attenuator_motor_squad))
+
+    mock_set.assert_called_once_with(
+        attenuator_motor_squad, position_demands, wait=True
+    )
 
 
 @patch("i19_bluesky.plans.optics_hutch_control_plans.bps.abs_set")

--- a/tests/unit_tests/eh2/test_optics_hutch_control.py
+++ b/tests/unit_tests/eh2/test_optics_hutch_control.py
@@ -1,6 +1,10 @@
 from unittest.mock import MagicMock, patch
 
 from bluesky.run_engine import RunEngine
+from dodal.devices.beamlines.i19.access_controlled.attenuator_motor_squad import (
+    AttenuatorMotorPositionDemands,
+    AttenuatorMotorSquad,
+)
 from dodal.devices.beamlines.i19.access_controlled.piezo_control import (
     AccessControlledPiezoActuator,
 )
@@ -14,8 +18,25 @@ from i19_bluesky.eh2 import (
     open_experiment_shutter,
 )
 from i19_bluesky.plans.optics_hutch_control_plans import (
+    apply_attenuator_positions,
     apply_voltage_to_piezo_actuators,
 )
+
+
+@patch("i19_bluesky.plans.optics_hutch_control_plans.bps.abs_set")
+async def test_apply_attenuator_positions(
+    mock_set: MagicMock, attenuator_motor_squad: AttenuatorMotorSquad, RE: RunEngine
+):
+    xy_demands = {"X": 15.71, "Y": 38.16}
+    filter_wheel_demands = {"W": 2}
+    position_demands = AttenuatorMotorPositionDemands(
+        continuous_demands=xy_demands, indexed_demands=filter_wheel_demands
+    )
+    RE(apply_attenuator_positions(attenuator_motor_squad, position_demands))
+
+    mock_set.assert_called_once_with(
+        attenuator_motor_squad, position_demands, wait=True
+    )
 
 
 @patch("i19_bluesky.plans.optics_hutch_control_plans.bps.abs_set")


### PR DESCRIPTION
* Resolves #113

* Motors for attenuator wedges and position of the filter wheel are demanded on an I19 EH-1 or EH-2 by calling these plans.

* The validated demand is passed on via REST call to the I19 Optics bluesky service

* Usual EH-1 and EH-2 plan unit tests with test fixture configuration