### PR TITLE
Remove ui-only parameters from serial

### DIFF
--- a/src/i19_bluesky/parameters/serial_parameters.py
+++ b/src/i19_bluesky/parameters/serial_parameters.py
@@ -24,6 +24,7 @@ class SerialExperiment(VisitParameters):
     two_theta_deg: float
     transmission_fraction: float
     wells_to_collect: dict[str, tuple]
+    wells_series_len: int  # how many wells to collect each arm
     rot_axis_start: float
     rot_axis_increment: float
     rotation_axis: RotationAxis = RotationAxis.PHI
@@ -36,6 +37,21 @@ class SerialExperiment(VisitParameters):
     @property
     def total_num_images(self) -> int:
         return self.images_per_well * self.total_num_wells
+
+    def split_wells_per_run(self) -> list[dict]:
+        """Divide wells into serirun list: each to be collected in one detector arm."""
+        wells = list(self.wells_to_collect.items())
+        run_list = [
+            dict(wells[i : i + self.wells_series_len])
+            for i in range(0, self.total_num_wells, self.wells_series_len)
+        ]
+        return run_list
+
+    def get_number_of_runs(self) -> int:
+        if self.total_num_wells // self.wells_series_len == 0:
+            return self.total_num_wells // self.wells_series_len
+        else:
+            return self.total_num_wells // self.wells_series_len + 1
 
     # @property
     # @abstractmethod

--- a/src/i19_bluesky/parameters/serial_parameters.py
+++ b/src/i19_bluesky/parameters/serial_parameters.py
@@ -1,10 +1,9 @@
 # from abc import abstractmethod
-from enum import StrEnum
 
 from dodal.devices.beamlines.i19.pin_col_stages import (
     PinColRequest,
 )
-from pydantic import BaseModel, computed_field
+from pydantic import computed_field
 
 from i19_bluesky.parameters.components import (
     DetectorType,
@@ -13,72 +12,6 @@ from i19_bluesky.parameters.components import (
     VisitParameters,
     ZebraRotationParams,
 )
-
-
-class GridType(StrEnum):
-    POLYMER = "Polymer"
-    SILICON = "Silicon"
-    KAPTON400 = "Kapton"
-    FILM = "Film"
-
-
-class GridParameters(BaseModel):
-    grid_type: GridType
-
-    x_steps: int
-    z_steps: int
-
-    @property
-    def x_step_size(self) -> float:
-        match self.grid_type:
-            case GridType.POLYMER | GridType.KAPTON400:
-                return 0.120
-            case GridType.SILICON:
-                return 0.125
-            case GridType.FILM:
-                return 0.100
-
-    @property
-    def z_step_size(self) -> float:
-        match self.grid_type:
-            case GridType.POLYMER | GridType.KAPTON400:
-                return 0.120
-            case GridType.SILICON:
-                return 0.125
-            case GridType.FILM:
-                return 0.100
-
-    @property
-    def city_block_x(self) -> float:
-        return (self.x_steps - 1) * self.x_step_size
-
-    @property
-    def city_block_z(self) -> float:
-        return (self.z_steps - 1) * self.z_step_size
-
-    @property
-    def total_num_wells(self) -> int:
-        return self.x_steps * self.z_steps
-
-
-class WellsSelection(BaseModel):
-    first: int
-    last: int
-    selected: list[int]  # NOTE this is 1-indexed
-    series_length: int  # How many in the same detector arm
-    manual_selection_enabled: bool = False
-
-    @computed_field
-    @property
-    def num_series(self) -> int:
-        if len(self.selected) % self.series_length == 0:
-            return len(self.selected) // self.series_length
-        else:
-            return len(self.selected) // self.series_length + 1
-
-    @property
-    def num_wells_to_collect(self) -> int:
-        return len(self.selected)
 
 
 class SerialExperiment(VisitParameters):
@@ -90,20 +23,19 @@ class SerialExperiment(VisitParameters):
     detector_distance_mm: float
     two_theta_deg: float
     transmission_fraction: float
-    grid: GridParameters
-    wells: WellsSelection
-    # Missing: , , sample_stage, also axes values
-    well_position: dict[int, tuple]
+    wells_to_collect: dict[str, tuple]
     rot_axis_start: float
     rot_axis_increment: float
     rotation_axis: RotationAxis = RotationAxis.PHI
 
-    # The other positions can be read from device for now and then set to detector
+    @property
+    def total_num_wells(self) -> int:
+        return len(self.wells_to_collect)
 
     @computed_field
     @property
     def total_num_images(self) -> int:
-        return self.images_per_well * self.wells.num_wells_to_collect
+        return self.images_per_well * self.total_num_wells
 
     # @property
     # @abstractmethod

--- a/src/i19_bluesky/parameters/serial_parameters.py
+++ b/src/i19_bluesky/parameters/serial_parameters.py
@@ -39,19 +39,13 @@ class SerialExperiment(VisitParameters):
         return self.images_per_well * self.total_num_wells
 
     def split_wells_per_run(self) -> list[dict]:
-        """Divide wells into serirun list: each to be collected in one detector arm."""
+        """Divide wells into run list: each to be collected in one detector arm."""
         wells = list(self.wells_to_collect.items())
         run_list = [
             dict(wells[i : i + self.wells_series_len])
             for i in range(0, self.total_num_wells, self.wells_series_len)
         ]
         return run_list
-
-    def get_number_of_runs(self) -> int:
-        if self.total_num_wells // self.wells_series_len == 0:
-            return self.total_num_wells // self.wells_series_len
-        else:
-            return self.total_num_wells // self.wells_series_len + 1
 
     # @property
     # @abstractmethod

--- a/src/i19_bluesky/serial/run_panda_plans/panda_serial_collection.py
+++ b/src/i19_bluesky/serial/run_panda_plans/panda_serial_collection.py
@@ -55,7 +55,7 @@ def trigger_panda(
     yield from bps.trigger(devices.eiger.drv.detector.arm)
     # Currently a test, will be modified as we solidify parameters going forwards
     # assumes a dictionary of integer keys and coordinates in a list
-    for well_num, coords in parameters.well_position.items():
+    for well_num, coords in parameters.wells_to_collect.items():
         yield from move_stage_x_and_z(coords[0], coords[2], devices.serial_stages)
         LOGGER.info(f"Moved to well {well_num}")
         if well_num % 2 == 0:

--- a/src/i19_bluesky/serial/run_panda_plans/panda_serial_collection.py
+++ b/src/i19_bluesky/serial/run_panda_plans/panda_serial_collection.py
@@ -58,22 +58,22 @@ def trigger_panda(
         LOGGER.info(f"Moved to well {well_num}")
         if i % 2 == 0:  # even in list
             LOGGER.info(
-                f"Rotate {parameters.panda_rotation_params.scan_end_deg} to\
-                    {parameters.panda_rotation_params.scan_start_deg}"
-            )
-            yield from bps.abs_set(
-                devices.diffractometer.phi,
-                parameters.panda_rotation_params.scan_start_deg,
-                wait=True,
-            )
-        else:  # odd idx in list
-            LOGGER.info(
                 f"Rotate {parameters.panda_rotation_params.scan_start_deg} to\
                 {parameters.panda_rotation_params.scan_end_deg}"
             )
             yield from bps.abs_set(
                 devices.diffractometer.phi,
                 parameters.panda_rotation_params.scan_end_deg,
+                wait=True,
+            )
+        else:  # odd idx in list
+            LOGGER.info(
+                f"Rotate {parameters.panda_rotation_params.scan_end_deg} to\
+                    {parameters.panda_rotation_params.scan_start_deg}"
+            )
+            yield from bps.abs_set(
+                devices.diffractometer.phi,
+                parameters.panda_rotation_params.scan_start_deg,
                 wait=True,
             )
 

--- a/src/i19_bluesky/serial/run_panda_plans/panda_serial_collection.py
+++ b/src/i19_bluesky/serial/run_panda_plans/panda_serial_collection.py
@@ -53,28 +53,28 @@ def trigger_panda(
     yield from arm_panda(devices.panda)
     LOGGER.info("Arm eiger")
     yield from bps.trigger(devices.eiger.drv.detector.arm)
-    # Currently a test, will be modified as we solidify parameters going forwards
-    # assumes a dictionary of integer keys and coordinates in a list
-    for well_num, coords in parameters.wells_to_collect.items():
+    for i, (well_num, coords) in enumerate(parameters.wells_to_collect.items()):
         yield from move_stage_x_and_z(coords[0], coords[2], devices.serial_stages)
         LOGGER.info(f"Moved to well {well_num}")
-        if well_num % 2 == 0:
+        if i % 2 == 0:  # even in list
             LOGGER.info(
-                f"Rotate {parameters.rot_axis_start} to\
+                f"Rotate {parameters.panda_rotation_params.scan_end_deg} to\
+                    {parameters.panda_rotation_params.scan_start_deg}"
+            )
+            yield from bps.abs_set(
+                devices.diffractometer.phi,
+                parameters.panda_rotation_params.scan_start_deg,
+                wait=True,
+            )
+        else:  # odd idx in list
+            LOGGER.info(
+                f"Rotate {parameters.panda_rotation_params.scan_start_deg} to\
                 {parameters.panda_rotation_params.scan_end_deg}"
             )
             yield from bps.abs_set(
                 devices.diffractometer.phi,
                 parameters.panda_rotation_params.scan_end_deg,
                 wait=True,
-            )
-        else:
-            LOGGER.info(
-                f"Rotate {parameters.panda_rotation_params.scan_end_deg} to\
-                    {parameters.rot_axis_start}"
-            )
-            yield from bps.abs_set(
-                devices.diffractometer.phi, parameters.rot_axis_start, wait=True
             )
 
 

--- a/tests/unit_tests/parameters/test_serial_parameters.py
+++ b/tests/unit_tests/parameters/test_serial_parameters.py
@@ -23,6 +23,7 @@ def dummy_serial_params():
         "two_theta_deg": 0,
         "transmission_fraction": 0.3,
         "wells_to_collect": {"01": (0, 0, 0), "02": (0.1, 0, 0)},
+        "wells_series_len": 2,
         "rot_axis_start": -5,
         "rot_axis_increment": 0.1,
         "rot_axis_end": 10,
@@ -51,6 +52,71 @@ def test_serial_parameters(dummy_serial_params):
 
     assert params.total_num_wells == 2
     assert params.total_num_images == 20
+
+
+@pytest.mark.parametrize(
+    "wells_to_collect, series_length, expected_run_list, expected_run_num",
+    [
+        (
+            {"01": (0, 0, 0), "02": (0.1, 0, 0)},
+            2,
+            [{"01": (0, 0, 0), "02": (0.1, 0, 0)}],
+            1,
+        ),
+        (
+            {"01": (0, 0, 0), "02": (0.1, 0, 0)},
+            1,
+            [{"01": (0, 0, 0)}, {"02": (0.1, 0, 0)}],
+            2,
+        ),
+        (
+            {
+                "01": (0, 0, 0),
+                "02": (0.1, 0, 0),
+                "05": (0.4, 0.0, 0.0),
+                "06": (0.0, 0.0, 0.1),
+                "08": (0.2, 0.0, 0.1),
+            },
+            3,
+            [
+                {"01": (0, 0, 0), "02": (0.1, 0, 0), "05": (0.4, 0.0, 0.0)},
+                {"06": (0.0, 0.0, 0.1), "08": (0.2, 0.0, 0.1)},
+            ],
+            2,
+        ),
+        (
+            {
+                "01": (0, 0, 0),
+                "02": (0.1, 0, 0),
+                "05": (0.4, 0.0, 0.0),
+                "06": (0.0, 0.0, 0.1),
+                "08": (0.2, 0.0, 0.1),
+            },
+            2,
+            [
+                {"01": (0, 0, 0), "02": (0.1, 0, 0)},
+                {"05": (0.4, 0.0, 0.0), "06": (0.0, 0.0, 0.1)},
+                {"08": (0.2, 0.0, 0.1)},
+            ],
+            3,
+        ),
+    ],
+)
+def test_split_wells_into_run_list_for_collection(
+    wells_to_collect,
+    series_length,
+    expected_run_list,
+    expected_run_num,
+    dummy_serial_params,
+):
+    params = SerialExperiment(**dummy_serial_params)
+    params.wells_to_collect = wells_to_collect
+    params.wells_series_len = series_length
+
+    wells_per_run = params.split_wells_per_run()
+
+    assert wells_per_run == expected_run_list
+    assert len(wells_per_run) == expected_run_num
 
 
 def test_serial_parameter_model_for_eh2(dummy_serial_params_eh2):

--- a/tests/unit_tests/parameters/test_serial_parameters.py
+++ b/tests/unit_tests/parameters/test_serial_parameters.py
@@ -4,27 +4,13 @@ import pytest
 
 from i19_bluesky.parameters.components import PandaRotationParams, ZebraRotationParams
 from i19_bluesky.parameters.serial_parameters import (
-    GridParameters,
-    GridType,
     SerialExperiment,
     SerialExperimentEh2,
-    WellsSelection,
 )
 
 
 @pytest.fixture
-def dummy_wells_settings():
-    return {
-        "first": 0,
-        "last": 5,
-        "selected": [1, 3, 5],
-        "series_length": 3,
-        "manual_selection_enabled": True,
-    }
-
-
-@pytest.fixture
-def dummy_serial_params(dummy_wells_settings):
+def dummy_serial_params():
     return {
         "hutch": "EH2",
         "visit": "/tmp/i19-2/cm12345-1",
@@ -36,71 +22,41 @@ def dummy_serial_params(dummy_wells_settings):
         "detector_distance_mm": 320,
         "two_theta_deg": 0,
         "transmission_fraction": 0.3,
-        "grid": {
-            "grid_type": "Silicon",
-            "x_steps": 20,
-            "z_steps": 20,
-        },
-        "aperture_request": "100um",
-        "detector_type": "EIGER",
-        "well_position": {1: (1, 2, 3)},
-        "wells": dummy_wells_settings,
+        "wells_to_collect": {"01": (0, 0, 0), "02": (0.1, 0, 0)},
         "rot_axis_start": -5,
         "rot_axis_increment": 0.1,
         "rot_axis_end": 10,
     }
 
 
-@pytest.mark.parametrize(
-    "grid_type, steps, expected_step_size, expected_block_size",
-    [
-        (GridType.POLYMER, (20, 20), (0.120, 0.120), (2.28, 2.28)),
-        (GridType.SILICON, (20, 20), (0.125, 0.125), (2.375, 2.375)),
-        (GridType.KAPTON400, (20, 20), (0.120, 0.120), (2.28, 2.28)),
-        (
-            GridType.FILM,
-            (20, 20),
-            (0.100, 0.100),
-            (pytest.approx(1.9, 1e-3), pytest.approx(1.9, 1e-3)),
-        ),
-    ],
-)
-def test_grid_parameters(grid_type, steps, expected_step_size, expected_block_size):
-    grid_params = GridParameters(
-        grid_type=grid_type, x_steps=steps[0], z_steps=steps[1]
-    )
-
-    assert grid_params.x_step_size == expected_step_size[0]
-    assert grid_params.z_step_size == expected_step_size[1]
-    assert grid_params.city_block_x == expected_block_size[0]
-    assert grid_params.city_block_z == expected_block_size[1]
-
-    assert grid_params.total_num_wells == 400
+@pytest.fixture
+def dummy_serial_params_eh2(dummy_serial_params):
+    eh2_spec_params = {
+        "aperture_request": "100um",
+        "detector_type": "EIGER",
+    }
+    return {**dummy_serial_params, **eh2_spec_params}
 
 
-def test_wells_selection(dummy_wells_settings):
-    params = WellsSelection(**dummy_wells_settings)
-
-    assert params.num_wells_to_collect == 3
-    assert params.num_series == 1
-
-
-def test_wells_selection_with_multiple_series(dummy_wells_settings):
-    dummy_wells_settings["series_length"] = 2
-
-    params = WellsSelection(**dummy_wells_settings)
-
-    assert params.num_series == 2
-
-
-def test_serial_parameter_model(dummy_serial_params):
+def test_serial_parameter_model_validates(dummy_serial_params):
     SerialExperiment.model_validate(dummy_serial_params)
 
 
-def test_serial_parameter_model_for_eh2(dummy_serial_params):
-    eh2_params = SerialExperimentEh2(**dummy_serial_params)
+def test_serial_parameters_eh2_model_validates(dummy_serial_params_eh2):
+    SerialExperimentEh2.model_validate(dummy_serial_params_eh2)
 
-    assert eh2_params.total_num_images == 30
+
+def test_serial_parameters(dummy_serial_params):
+    params = SerialExperiment(**dummy_serial_params)
+
+    assert params.total_num_wells == 2
+    assert params.total_num_images == 20
+
+
+def test_serial_parameter_model_for_eh2(dummy_serial_params_eh2):
+    eh2_params = SerialExperimentEh2(**dummy_serial_params_eh2)
+
+    assert eh2_params.total_num_images == 20
     assert eh2_params.rotation_axis == "phi"
     assert eh2_params.collection_directory == Path("/tmp/i19-2/cm12345-1/foo")
 

--- a/tests/unit_tests/serial/conftest.py
+++ b/tests/unit_tests/serial/conftest.py
@@ -27,8 +27,6 @@ from i19_bluesky.parameters.devices_composites import (
 )
 from i19_bluesky.parameters.serial_parameters import (
     DetectorType,
-    GridParameters,
-    GridType,
     SerialExperimentEh2,
 )
 
@@ -173,18 +171,7 @@ async def devices_zebra(
 
 
 @pytest.fixture
-def dummy_wells_settings():
-    return {
-        "first": 0,
-        "last": 5,
-        "selected": [1, 3, 5],
-        "series_length": 3,
-        "manual_selection_enabled": True,
-    }
-
-
-@pytest.fixture
-def parameters(dummy_wells_settings):
+def parameters():
     return SerialExperimentEh2(
         hutch=HutchName.EH2,
         visit=Path("/tmp/i19-2/cm12345-1"),
@@ -196,15 +183,9 @@ def parameters(dummy_wells_settings):
         detector_distance_mm=320,
         two_theta_deg=0,
         transmission_fraction=0.3,
-        grid=GridParameters(
-            grid_type=GridType.SILICON,
-            x_steps=20,
-            z_steps=20,
-        ),
         aperture_request=PinColRequest.PCOL100,
         detector_type=DetectorType.EIGER,
-        well_position={1: (1, 2, 3)},
-        wells=dummy_wells_settings,
+        wells_to_collect={"1": (1, 2, 3)},
         rot_axis_start=0,
         rot_axis_increment=0.1,
     )

--- a/tests/unit_tests/serial/conftest.py
+++ b/tests/unit_tests/serial/conftest.py
@@ -186,6 +186,7 @@ def parameters():
         aperture_request=PinColRequest.PCOL100,
         detector_type=DetectorType.EIGER,
         wells_to_collect={"1": (1, 2, 3)},
+        wells_series_len=1,
         rot_axis_start=0,
         rot_axis_increment=0.1,
     )

--- a/tests/unit_tests/serial/run_panda_plans/test_panda_serial_collection.py
+++ b/tests/unit_tests/serial/run_panda_plans/test_panda_serial_collection.py
@@ -31,7 +31,7 @@ async def test_setup_sample_stage(
 
 
 @pytest.mark.parametrize(
-    "well_positions,phival", [({1: [1, 2, 3]}, 5.0), ({2: [1, 2, 3]}, 6.0)]
+    "well_positions,phival", [({"01": [1, 2, 3]}, 5.0), ({"02": [1, 2, 3]}, 6.0)]
 )
 @patch("i19_bluesky.serial.run_panda_plans.panda_serial_collection.bps.trigger")
 @patch("i19_bluesky.serial.run_panda_plans.panda_serial_collection.bps.abs_set")
@@ -52,7 +52,7 @@ async def test_trigger_panda(
     mock_move_stage_x_and_z: MagicMock,
     mock_set_value_for_params: MagicMock,
     mock_arm_or_disarm: MagicMock,
-    well_positions: dict[int, tuple],
+    well_positions: dict[str, tuple],
     phival: int,
     parameters: SerialExperimentEh2,
     devices: SerialCollectionEh2PandaComposite,

--- a/tests/unit_tests/serial/run_panda_plans/test_panda_serial_collection.py
+++ b/tests/unit_tests/serial/run_panda_plans/test_panda_serial_collection.py
@@ -1,6 +1,5 @@
 from unittest.mock import MagicMock, call, patch
 
-import pytest
 from bluesky.run_engine import RunEngine
 from ophyd_async.core import get_mock_put
 
@@ -30,9 +29,6 @@ async def test_setup_sample_stage(
     mock_phi_velocity.assert_called_once_with(1.0)
 
 
-@pytest.mark.parametrize(
-    "well_positions,phival", [({"01": [1, 2, 3]}, 5.0), ({"02": [1, 2, 3]}, 6.0)]
-)
 @patch("i19_bluesky.serial.run_panda_plans.panda_serial_collection.bps.trigger")
 @patch("i19_bluesky.serial.run_panda_plans.panda_serial_collection.bps.abs_set")
 @patch("i19_bluesky.serial.run_panda_plans.panda_serial_collection.move_stage_x_and_z")
@@ -43,7 +39,7 @@ async def test_setup_sample_stage(
     "i19_bluesky.serial.run_panda_plans.panda_serial_collection.setup_panda_for_rotation"
 )
 @patch("i19_bluesky.serial.run_panda_plans.panda_serial_collection.setup_sample_stage")
-async def test_trigger_panda(
+def test_trigger_panda_call_order(
     mock_setup_sample_stage: MagicMock,
     mock_setup_panda_for_rotation: MagicMock,
     mock_arm_panda: MagicMock,
@@ -52,14 +48,12 @@ async def test_trigger_panda(
     mock_move_stage_x_and_z: MagicMock,
     mock_set_value_for_params: MagicMock,
     mock_arm_or_disarm: MagicMock,
-    well_positions: dict[str, tuple],
-    phival: int,
     parameters: SerialExperimentEh2,
     devices: SerialCollectionEh2PandaComposite,
     RE: RunEngine,
 ):
-    parameters.wells_to_collect = well_positions
-    parameters.rot_axis_start = 5
+    parameters.wells_to_collect = {"01": (1, 2, 3)}
+    parameters.rot_axis_start = 5.0
     parent_mock = MagicMock()
     parent_mock.attach_mock(mock_set_value_for_params, "mock_set_value_for_params")
     parent_mock.attach_mock(mock_move_stage_x_and_z, "mock_move_stage_x_and_z")
@@ -82,7 +76,7 @@ async def test_trigger_panda(
         call.mock_arm_panda(devices.panda),
         call.mock_arm_or_disarm(devices.eiger.drv.detector.arm),
         call.mock_move_stage_x_and_z(1, 3, devices.serial_stages),
-        call.mock_set_value_for_params(devices.diffractometer.phi, phival, wait=True),
+        call.mock_set_value_for_params(devices.diffractometer.phi, 5.0, wait=True),
     ]
     parent_mock.assert_has_calls(expected_calls, any_order=True)
 

--- a/tests/unit_tests/serial/run_panda_plans/test_panda_serial_collection.py
+++ b/tests/unit_tests/serial/run_panda_plans/test_panda_serial_collection.py
@@ -58,7 +58,7 @@ async def test_trigger_panda(
     devices: SerialCollectionEh2PandaComposite,
     RE: RunEngine,
 ):
-    parameters.well_position = well_positions
+    parameters.wells_to_collect = well_positions
     parameters.rot_axis_start = 5
     parent_mock = MagicMock()
     parent_mock.attach_mock(mock_set_value_for_params, "mock_set_value_for_params")

--- a/tests/unit_tests/serial/run_panda_plans/test_panda_serial_collection.py
+++ b/tests/unit_tests/serial/run_panda_plans/test_panda_serial_collection.py
@@ -52,7 +52,7 @@ def test_trigger_panda_call_order(
     devices: SerialCollectionEh2PandaComposite,
     RE: RunEngine,
 ):
-    parameters.wells_to_collect = {"01": (1, 2, 3)}
+    parameters.wells_to_collect = {"01": (0, 0, 0), "10": (1, 0, 0)}
     parameters.rot_axis_start = 5.0
     parent_mock = MagicMock()
     parent_mock.attach_mock(mock_set_value_for_params, "mock_set_value_for_params")
@@ -75,7 +75,9 @@ def test_trigger_panda_call_order(
         ),
         call.mock_arm_panda(devices.panda),
         call.mock_arm_or_disarm(devices.eiger.drv.detector.arm),
-        call.mock_move_stage_x_and_z(1, 3, devices.serial_stages),
+        call.mock_move_stage_x_and_z(0, 0, devices.serial_stages),
+        call.mock_move_stage_x_and_z(1, 0, devices.serial_stages),
+        call.mock_set_value_for_params(devices.diffractometer.phi, 6.0, wait=True),
         call.mock_set_value_for_params(devices.diffractometer.phi, 5.0, wait=True),
     ]
     parent_mock.assert_has_calls(expected_calls, any_order=True)

--- a/uv.lock
+++ b/uv.lock
@@ -1066,8 +1066,8 @@ wheels = [
 
 [[package]]
 name = "dls-dodal"
-version = "2.2.4.dev3+gd4c4ae983"
-source = { git = "https://github.com/DiamondLightSource/dodal.git?rev=main#d4c4ae98370aa28bbe4458f087b742445209e5ca" }
+version = "2.2.4.dev10+g0649293ed"
+source = { git = "https://github.com/DiamondLightSource/dodal.git?rev=main#0649293ed97538713ef77ab6e6f55fe984abd616" }
 dependencies = [
     { name = "aiofiles" },
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -1066,8 +1066,8 @@ wheels = [
 
 [[package]]
 name = "dls-dodal"
-version = "2.2.4.dev10+g0649293ed"
-source = { git = "https://github.com/DiamondLightSource/dodal.git?rev=main#0649293ed97538713ef77ab6e6f55fe984abd616" }
+version = "2.3.1.dev2+gf637d5d25"
+source = { git = "https://github.com/DiamondLightSource/dodal.git?rev=main#f637d5d258172bb1a6daff15dc96e005daedcbbf" }
 dependencies = [
     { name = "aiofiles" },
     { name = "aiohttp" },


### PR DESCRIPTION
* Remove the grid and well selection parameters from the serial parameter model, as they are only relevant on the UI side and not needed in the plan.
* Add the two parameters needed: a dictionary with the selected wells coordinates and the length of each "run" (ie. how many wells should be collected in one detector arm)
* Add a method to split the wells into runs before plan starts